### PR TITLE
Make year selector a dropdown if too long

### DIFF
--- a/frontend/src/SingleDataSelector.tsx
+++ b/frontend/src/SingleDataSelector.tsx
@@ -1,12 +1,11 @@
 import { ChangeEvent } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { Interval } from 'luxon'
-import YearSelector from './YearSelector'
-import DataSourceSelector from './DatasetSelector'
-import { changeMapSelection, changeDataSource, changeDateRange, selectSelections } from './appSlice'
-import { RootState } from './store'
-import { MapVisualization, MapVisualizationId } from './MapVisualization'
 import css from './DataSelector.module.css'
+import DataSourceSelector from './DatasetSelector'
+import { MapVisualization, MapVisualizationId } from './MapVisualization'
+import YearSelector from './YearSelector'
+import { changeDataSource, changeDateRange, changeMapSelection, selectSelections } from './appSlice'
+import { RootState } from './store'
 
 function SingleDataSelector({ maps }: { maps: Record<MapVisualizationId, MapVisualization> }) {
     const selection = useSelector((state: RootState) =>
@@ -15,10 +14,6 @@ function SingleDataSelector({ maps }: { maps: Record<MapVisualizationId, MapVisu
 
     const dispatch = useDispatch()
 
-    const onDateRangeChange = (event: ChangeEvent<HTMLInputElement>) => {
-        const dateRange = Interval.fromISO(event.target.value)
-        dispatch(changeDateRange(dateRange))
-    }
     const onDataSourceChange = (event: ChangeEvent<HTMLInputElement>) => {
         const dataset = parseInt(event.target.value, 10)
         dispatch(changeDataSource(dataset))
@@ -61,7 +56,7 @@ function SingleDataSelector({ maps }: { maps: Record<MapVisualizationId, MapVisu
                                 id={map.id.toString()}
                                 years={map.date_ranges_by_source[selection.dataSource]}
                                 selectedYear={selection.dateRange}
-                                onSelectionChange={onDateRangeChange}
+                                onChange={(dateRange) => dispatch(changeDateRange(dateRange))}
                             />
                         )}
                         {selection !== undefined && shouldShowDatasets(map) && (

--- a/frontend/src/SubSelector.module.css
+++ b/frontend/src/SubSelector.module.css
@@ -19,3 +19,6 @@
 .sub-selector input:checked + label {
     text-decoration: underline;
 }
+.year-dropdown {
+    margin-left: 1em;
+}

--- a/frontend/src/YearSelector.tsx
+++ b/frontend/src/YearSelector.tsx
@@ -1,11 +1,12 @@
-import { ChangeEvent, Fragment } from 'react'
+import { MenuItem, Select } from '@mui/material'
 import { Interval } from 'luxon'
+import { Fragment } from 'react'
 import css from './SubSelector.module.css'
 
 type Props = {
     years: Interval[]
     selectedYear: Interval
-    onSelectionChange: (event: ChangeEvent<HTMLInputElement>) => void
+    onChange: (date: Interval) => void
     id: string
 }
 
@@ -16,7 +17,27 @@ const readable = (interval: Interval) => {
     return `${interval.start.year.toString()}-${interval.end.year.toString()}`
 }
 
-function YearSelector({ years, selectedYear, onSelectionChange, id }: Props) {
+function DropdownYearSelector({ years, selectedYear, onChange, id }: Props) {
+    return (
+        <div className={css.subSelector}>
+            <p>Year:</p>
+            <Select
+                className={css.yearDropdown}
+                value={selectedYear.toISODate()}
+                onChange={(e) => onChange(Interval.fromISO(e.target.value))}
+                id={id}
+            >
+                {years.map((year) => (
+                    <MenuItem key={year.toISODate()} value={year.toISODate()}>
+                        {readable(year)}
+                    </MenuItem>
+                ))}
+            </Select>
+        </div>
+    )
+}
+
+function ButtonsYearSelector({ years, selectedYear, onChange, id }: Props) {
     const getYears = () => {
         return years.map((year) => (
             <Fragment key={year.toISODate()}>
@@ -24,7 +45,7 @@ function YearSelector({ years, selectedYear, onSelectionChange, id }: Props) {
                     type="radio"
                     value={year.toISODate()}
                     id={id + year.toISODate()}
-                    onChange={onSelectionChange}
+                    onChange={(e) => onChange(Interval.fromISO(e.target.value))}
                     checked={year.equals(selectedYear)}
                 />
                 <label htmlFor={id + year.toISODate()}>{readable(year)}</label>
@@ -36,6 +57,27 @@ function YearSelector({ years, selectedYear, onSelectionChange, id }: Props) {
             <p>Year:</p>
             {getYears()}
         </div>
+    )
+}
+
+function YearSelector({ years, selectedYear, onChange, id }: Props) {
+    if (years.length > 5) {
+        return (
+            <DropdownYearSelector
+                years={years}
+                selectedYear={selectedYear}
+                onChange={onChange}
+                id={id}
+            />
+        )
+    }
+    return (
+        <ButtonsYearSelector
+            years={years}
+            selectedYear={selectedYear}
+            onChange={onChange}
+            id={id}
+        />
     )
 }
 

--- a/frontend/src/stories/YearSelector.stories.tsx
+++ b/frontend/src/stories/YearSelector.stories.tsx
@@ -1,21 +1,21 @@
 import { ComponentMeta } from '@storybook/react'
 import { Interval } from 'luxon'
-import YearSelector from '../YearSelector'
+import FewYearSelector from '../YearSelector'
 
 export default {
     title: 'YearSelector',
-    component: YearSelector,
-} as ComponentMeta<typeof YearSelector>
+    component: FewYearSelector,
+} as ComponentMeta<typeof FewYearSelector>
 
 export const ThreeYears = () => {
     return (
-        <YearSelector
+        <FewYearSelector
             years={[
                 Interval.fromISO('2020-01-01/2020-12-31'),
                 Interval.fromISO('2021-01-01/2021-12-31'),
             ]}
             selectedYear={Interval.fromISO('2020-01-01/2020-12-31')}
-            onSelectionChange={() => {}}
+            onChange={() => {}}
             id="year-selector"
         />
     )


### PR DESCRIPTION
The list of years wasn't fitting comfortably in the data selector for datasets that spanned many years.