### PR TITLE
Fixed an unhandled error which was caused by uploading an empty csv

### DIFF
--- a/backend/src/controller/uploader_controller.rs
+++ b/backend/src/controller/uploader_controller.rs
@@ -45,6 +45,8 @@ enum Error {
         row: usize,
         parsed_data: data::Parsed,
     },
+    #[display(fmt = "At least one value in the dataset must be numerical.")]
+    DataNonNumeric,
     #[display(fmt = "Duplicate datasets: {_0:#?}")]
     DuplicateDatasets(Vec<Dataset>),
     DuplicateDataSource(DataSource),
@@ -179,6 +181,9 @@ fn parse_csv(file: &File, metadata: &UploadMetadata) -> Result<HashSet<data::Par
                 }
             }
         }
+    }
+    if new_data.is_empty() {
+        return Err(Error::DataNonNumeric)
     }
     Ok(new_data)
 }

--- a/frontend/src/MapApi.ts
+++ b/frontend/src/MapApi.ts
@@ -166,6 +166,7 @@ export type UploadError =
               link: string
           }
       }
+    | { name: 'DataNonNumeric' }
     | { name: 'DataSourceIncomplete' }
     | { name: 'DataSourceLinkInvalid'; info: string }
     | { name: 'MissingMetadata' }

--- a/frontend/src/uploader/Uploader.tsx
+++ b/frontend/src/uploader/Uploader.tsx
@@ -92,6 +92,15 @@ function Error({
                         </ul>
                     </>
                 )
+            case 'DataNonNumeric':
+                return (
+                    <>
+                        <p>At least one value must be numeric.</p>
+                        <p>
+                            Make sure values do not have symbols attached in csv (e.g. $, %, etc.)
+                        </p>
+                    </>
+                )
             case 'DuplicateDataSource':
                 return <p>Duplicate data source: {e.info.name}</p>
             case 'DataSourceIncomplete':


### PR DESCRIPTION
Previous behavior allowed uploading an empty csv or one that contained all non-numeric values. This would break the editor if that dataset was selected. New behavior does not allow for uploading datasets unless at least one value is numeric.