### PR TITLE
Added subtitle and empty map title

### DIFF
--- a/frontend/src/MapTitle.module.css
+++ b/frontend/src/MapTitle.module.css
@@ -1,4 +1,5 @@
-#map-title {
+#map-title,
+#no-metric-title {
     font-weight: 400;
     font-size: 25px;
     line-height: 48px;
@@ -10,4 +11,12 @@
 #empty-title {
     height: 48px;
     margin-top: 25px;
+}
+
+#map-subtitle {
+    font-weight: 400;
+    font-size: 15px;
+    margin: 0 0 25px 0;
+    width: 82%;
+    text-align: center;
 }

--- a/frontend/src/MapTitle.tsx
+++ b/frontend/src/MapTitle.tsx
@@ -1,7 +1,12 @@
 import { IconButton, styled, Tooltip, TooltipProps, tooltipClasses } from '@mui/material'
 import { Info } from '@mui/icons-material'
+import { useSelector } from 'react-redux'
 import { MapVisualization } from './MapVisualization'
+import { RootState } from './store'
+import { stateId } from './appSlice'
 import css from './MapTitle.module.css'
+import counties from './Counties'
+import states from './States'
 
 const getTitle = (selectedMaps: MapVisualization[]) => {
     if (selectedMaps.length > 1) {
@@ -11,6 +16,18 @@ const getTitle = (selectedMaps: MapVisualization[]) => {
         return ''
     }
     return selectedMaps[0].displayName
+}
+
+const getSubtitle = (countyId: number | undefined, region: string) => {
+    if (countyId) {
+        const countyName = counties.get(countyId)
+        const stateName = states.get(stateId(countyId))
+        return `${countyName}, ${stateName}`
+    }
+    if (region === 'USA') {
+        return 'United States'
+    }
+    return 'World'
 }
 
 type Props = {
@@ -31,25 +48,34 @@ const BigTooltip = styled(({ className, ...props }: TooltipProps) => (
 }))
 
 function MapTitle({ selectedMapVisualizations, isNormalized }: Props) {
+    const countyId = useSelector((state: RootState) => state.app.county)
+    const region = useSelector((state: RootState) => state.app.region)
     return (
-        <h3 id={css.mapTitle}>
-            {getTitle(selectedMapVisualizations)}
-            {isNormalized && (
-                <BigTooltip
-                    title="The normalized value is the percentile
+        <>
+            <h3 id={css.mapTitle}>
+                {getTitle(selectedMapVisualizations)}
+                {isNormalized && (
+                    <BigTooltip
+                        title="The normalized value is the percentile
                 of the raw data. If you select multiple data,
                 we take the mean of the ranked values."
-                >
-                    <IconButton aria-label="info" size="large">
-                        <Info />
-                    </IconButton>
-                </BigTooltip>
-            )}
-        </h3>
+                    >
+                        <IconButton aria-label="info" size="large">
+                            <Info />
+                        </IconButton>
+                    </BigTooltip>
+                )}
+            </h3>
+            <p id={css.mapSubtitle}>{getSubtitle(countyId, region)}</p>
+        </>
     )
 }
 
 export function EmptyMapTitle() {
-    return <div id={css.emptyTitle} />
+    return (
+        <div id={css.emptyTitle}>
+            <h1 id={css.noMetricTitle}>No metric selected</h1>
+        </div>
+    )
 }
 export default MapTitle


### PR DESCRIPTION
This pull request introduces enhancements to the `MapTitle` component by adding a subtitle, improving the styling, and making the component more dynamic based on the application's state. The most significant changes include the addition of a subtitle element, updates to the CSS for new styles, and the use of Redux state to dynamically determine the subtitle content.

### Enhancements to `MapTitle` component:

* Added a new `getSubtitle` function to generate a subtitle based on the selected county or region. The subtitle displays the county and state name when a county is selected, "United States" for the USA region, or "World" otherwise. 
* Updated the `MapTitle` component to use Redux selectors (`useSelector`) to fetch the `countyId` and `region` from the application's state, and included the subtitle in the rendered output. 

### Styling updates:

* Added a new CSS class `#map-subtitle` to style the subtitle with specific font size, alignment, and margins. 
* Updated the `EmptyMapTitle` component to include a new header with the `#no-metric-title` style, ensuring consistent styling when no metric is selected. 